### PR TITLE
feat: noticket - Increase number of allowed versions of build-essential

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -1,6 +1,11 @@
 ---
 driver:
   name: vagrant
+  require_chef_omnibus: 12.5
+  provision: true
+  vagrantfiles:
+    - vagrant.rb
+
 
 provisioner:
   name: chef_zero

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### 0.3.0
+  - Support more versions of build-essential
+  - Improve reliability of tests by running apt-update before them
+
 ### 0.2.1
   - Support detecting AWS region from ohai data.
 
@@ -42,5 +46,5 @@
 
 ## Enhancements
   - Add library to extend existing chef resource using not_if and only_if.
-    Includes: instance_running?, intance_stopped?, 
+    Includes: instance_running?, intance_stopped?,
     instance_terminated?, instance_stopping?

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,8 @@ maintainer_email 'mail@jameslegg.co.uk'
 license          'Apache 2.0'
 description      'provides LWRPs for interaction with AWS'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '0.2.1'
-depends          'build-essential', '~> 2.0'
+version          '0.3.0'
+# Last version that supports chef 12.5
+depends          'build-essential', '<= 7.03'
 depends          'apt'
 supports         'ubuntu'

--- a/vagrant.rb
+++ b/vagrant.rb
@@ -1,0 +1,5 @@
+Vagrant.configure(2) do |config|
+  config.vm.provision 'shell', inline: <<-SHELL
+     sudo apt-get update -y
+  SHELL
+end


### PR DESCRIPTION
So `sc-mongodb` needs `build-essential >=5.0.0` 

The version constraint here, which appears through `conv_essential` prevents the new Graylog cookbook from being able to satisfy its dependencies.

Looking at the changelog for build-essential - https://github.com/chef-cookbooks/build-essential/blob/master/CHANGELOG.md 

I think we can safely depend on `<= 7.03` and still maintain compatibility with Chef 12.5 and there are no breaking changes we care about.

I've tested the cookbook with Kitchen and more tests pass than master does currently. (The current master seems to fail on Chef 12.5 due to a dependency on apt_update that is only in Chef 12.7+ https://docs.chef.io/resource_apt_update.html)

The  tests for `instance-status-ubuntu-*` currently fail due to 

```           NoMethodError
           -------------
           Undefined method or attribute `ec2' on `node'
```

But I don't think that's related to `build-essential`

