### PR TITLE
fix: noticket - Switch how we install chef_gems as the old way takes 20

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+### 2.0.0
+  - Switch to using new gem syntax in metadata.rb as with Chef Client 14 the
+  chef_gem resource was taking 20 mins per gem. This does mean this cookbook
+  now only supports chef client 14+
+
 ### 1.1.0
   - Support `mock` attributes for cookbook testing.
 

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,5 +4,8 @@ maintainer_email 'mail@jameslegg.co.uk'
 license          'Apache 2.0'
 description      'provides LWRPs for interaction with AWS'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '1.1.0'
+version          '2.0.0'
 supports         'ubuntu'
+
+gem 'aws-sdk-resources'
+gem 'aws-sdk'

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -2,24 +2,4 @@
 # Cookbook Name:: jlaws
 # Recipe:: default
 #
-chef_gem 'aws-sdk-resources' do
-  action :install
-  compile_time true
-  version node['jlaws']['aws_sdk_resources_ver']
-  # --conservative to not upgrade existing gems meeting version
-  # --no-wrappers to avoid installing a exectuable that may conflict
-  # with other versions installed by other cookbooks/gems.
-  # The --force option overwrites any executables left over from aws-sdk
-  options('--conservative --no-wrappers --force')
-end
-
-chef_gem 'aws-sdk' do
-  action :install
-  compile_time true
-  version node['jlaws']['aws_sdk_ver']
-  # Use force to make a side by side gem install work with aws-sdk < 2.0
-  # (The aws cookbook use the v2 sdk)
-  options('--no-wrappers --force')
-end
-
 require 'aws-sdk'


### PR DESCRIPTION
mins per gem on Chef Client 14