### PR TITLE
fix: OPS-1151 - Fix region defaults

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -9,7 +9,6 @@ provisioner:
   name: dokken
 
 platforms:
-
   - name: aws-linux
     driver:
       pid_one_command: /sbin/init

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+### 2.0.1
+  - Fix default region if `nil` is passed in.
+
 ### 2.0.0
   - Only install required parts of AWS SDK
   - Upgrade to support only Chef Client 14+, Chef Client 12 support is no more

--- a/libraries/ec2_node_status.rb
+++ b/libraries/ec2_node_status.rb
@@ -23,7 +23,7 @@ module JlawsHelper
     def ec2_instance_state(instance_id,
                            aws_access_key_id = nil,
                            aws_secret_access_key = nil,
-                           aws_region = 'us-east-1',
+                           aws_region = nil,
                            mock = nil
                           )
       # Support mocking results for cookbook testing.
@@ -32,6 +32,7 @@ module JlawsHelper
       end
 
       # Fetch instance status from AWS.
+      aws_region ||= 'us-east-1'
       if node.key?('ec2')
          aws_region = node.ec2.placement_availability_zone.chop
       end

--- a/libraries/s3_databag_secret.rb
+++ b/libraries/s3_databag_secret.rb
@@ -4,7 +4,7 @@ class Chef::Recipe::Jlaws
   def self.S3DataBagSecret(s3_bucket, s3_path,
                            aws_access_key_id = nil,
                            aws_secret_access_key = nil,
-                           aws_region = 'us-east-1',
+                           aws_region = nil,
                            mock = nil
                           )
     # Support mocking results for cookbook testing.
@@ -13,6 +13,7 @@ class Chef::Recipe::Jlaws
     end
 
     # Fetch secret from AWS.
+    aws_region ||= 'us-east-1'
     if aws_access_key_id
       s3 = Aws::S3::Client.new(
         :access_key_id => aws_access_key_id,

--- a/libraries/secrets_manger.rb
+++ b/libraries/secrets_manger.rb
@@ -3,7 +3,7 @@ class Chef::Recipe::Jlaws
   def self.SecretsManager(secret_id,
                           aws_access_key_id = nil,
                           aws_secret_access_key = nil,
-                          aws_region = 'us-east-1',
+                          aws_region = nil,
                           mock = nil
                          )
     # Support mocking results for cookbook testing.
@@ -12,6 +12,7 @@ class Chef::Recipe::Jlaws
     end
 
     # Fetch secret from AWS.
+    aws_region ||= 'us-east-1'
     if aws_access_key_id
       sm = Aws::SecretsManager::Client.new(
         :access_key_id => aws_access_key_id,

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'mail@jameslegg.co.uk'
 license          'Apache 2.0'
 description      'provides LWRPs for interaction with AWS'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '2.0.0'
+version          '2.0.1'
 supports         'ubuntu', '=18.04'
 supports         'amazon'
 


### PR DESCRIPTION
```bash
$ kitchen list
Instance                     Driver  Provisioner  Verifier  Transport  Last Action  Last Error
default-aws-linux            Dokken  Dokken       Busser    Dokken     Verified     <None>
default-ubuntu-1804          Dokken  Dokken       Busser    Dokken     Verified     <None>
default-aws-linux-2          Dokken  Dokken       Busser    Dokken     Verified     <None>
instance-status-aws-linux    Dokken  Dokken       Busser    Dokken     Verified     <None>
instance-status-ubuntu-1804  Dokken  Dokken       Busser    Dokken     Verified     <None>
instance-status-aws-linux-2  Dokken  Dokken       Busser    Dokken     Verified     <None>
secrets-manager-aws-linux    Dokken  Dokken       Busser    Dokken     Verified     <None>
secrets-manager-ubuntu-1804  Dokken  Dokken       Busser    Dokken     Verified     <None>
secrets-manager-aws-linux-2  Dokken  Dokken       Busser    Dokken     Verified     <None>
```